### PR TITLE
Add statemachine parser, unit test and benchmark

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,14 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="Fallenwood.LettuceEncrypt" Version="1.4.0-alpha0-beta.19" />
     <PackageVersion Include="Fallenwood.McMaster.AspNetCore.Kestrel.Certificates" Version="1.0.0" />
+
+    <!-- tests -->
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
 </Project>

--- a/Xiangyao.slnx
+++ b/Xiangyao.slnx
@@ -1,4 +1,8 @@
 <Solution>
+  <Folder Name="/tests/">
+    <Project Path="tests\Xiangyao.Benchmarks\Xiangyao.Benchmarks.csproj" Type="Classic C#" />
+    <Project Path="tests\Xiangyao.UnitTests\Xiangyao.UnitTests.csproj" Type="Classic C#" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src\Xiangyao\Xiangyao.csproj" />
   </Folder>
@@ -9,5 +13,6 @@
     <File Path="Directory.Build.props" />
     <File Path="Directory.Packages.props" />
     <File Path="Dockerfile" />
+    <File Path="Dockerfile.distroless" />
   </Folder>
 </Solution>

--- a/src/Xiangyao/AssemblyInfo.cs
+++ b/src/Xiangyao/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Xiangyao.UnitTests")]
+[assembly: InternalsVisibleTo("Xiangyao.Benchmarks")]

--- a/src/Xiangyao/Docker/ILabelParser.cs
+++ b/src/Xiangyao/Docker/ILabelParser.cs
@@ -14,8 +14,9 @@ internal interface ILabelParser {
   }
 
   public bool ParseEnabled(List<KeyValuePair<string, string>> labels) {
-    var enabled = labels.FirstOrDefault(e =>
-      string.Equals(e.Key, XiangyaoConstants.EnableLabelKey, StringComparison.OrdinalIgnoreCase))
+    var enabled = labels
+      .FirstOrDefault(e =>
+        string.Equals(e.Key, XiangyaoConstants.EnableLabelKey, StringComparison.OrdinalIgnoreCase))
       .Value;
 
     if (string.IsNullOrEmpty(enabled)
@@ -27,15 +28,15 @@ internal interface ILabelParser {
   }
 
   public string ParseHost(ContainerListResponse container) {
-    var fisrtNetwork = container.NetworkSettings.Networks.Values.First();
+    var fisrtNetwork = container.NetworkSettings?.Networks?.Values.First();
 
-    var host = fisrtNetwork.Aliases?.FirstOrDefault();
+    var host = fisrtNetwork?.Aliases?.FirstOrDefault();
 
     if (string.IsNullOrEmpty(host)) {
-      host = fisrtNetwork.IPAddress;
+      host = fisrtNetwork?.IPAddress;
     }
 
-    return host;
+    return host ?? string.Empty;
   }
 
   public string ParseSchema(List<KeyValuePair<string, string>> labels) {

--- a/src/Xiangyao/Docker/StateMachineLabelParser.cs
+++ b/src/Xiangyao/Docker/StateMachineLabelParser.cs
@@ -1,0 +1,114 @@
+﻿namespace Xiangyao;
+
+internal sealed class StateMachineLabelParser : ILabelParser {
+  public bool Parse(KeyValuePair<string, string> label, DefaultDictionary<string, RouteConfig> parsedLabels) {
+    var stateMachine = new StateMachine(label.Key, label.Value);
+
+    stateMachine.Parse(parsedLabels);
+
+    return true;
+  }
+
+  public enum State {
+    NotStarted,
+    Processing,
+    Tokenizied,
+    Completed,
+  }
+
+  internal class StateMachine(string key, string value) {
+    int index = 0;
+    int tokenStart = 0;
+    int tokenIndex = 0;
+    State state = State.NotStarted;
+    bool routes = false;
+    bool match = false;
+    string? routeName = null;
+
+    // xiangyao.routes.nginx_http.match.host=localhost:5000
+    public void Parse(DefaultDictionary<string, RouteConfig> parsedLabels) {
+      while (true) {
+        if (state == State.Completed) {
+          break;
+        }
+
+        if (state == State.NotStarted) {
+          index = 0;
+          tokenStart = 0;
+          state = State.Processing;
+          continue;
+        }
+
+        if (state == State.Tokenizied) {
+          var token = key[tokenStart..index];
+
+          index++;
+          tokenStart = index;
+
+          if (tokenIndex == 0) {
+            // NOOP
+          } else if (tokenIndex == 1) {
+            if (string.Equals(token, "routes", StringComparison.OrdinalIgnoreCase)) {
+              routes = true;
+            }
+          }
+
+          if (routes) {
+            if (tokenIndex == 2) {
+              routeName = token;
+            } else if (tokenIndex == 3) {
+              if (string.Equals(token, "match", StringComparison.OrdinalIgnoreCase)) {
+                match = true;
+              }
+            }
+
+            if (match) {
+              if (tokenIndex == 4) {
+                var route = parsedLabels[routeName!]!;
+
+                switch (token) {
+                  case "host": {
+                      route.Match.Hosts.Add(value);
+                      break;
+                    }
+                  case "hosts": {
+                      var hosts = value.Split(';');
+                      route.Match.Hosts = [.. hosts];
+                      break;
+                    }
+                  case "path": {
+                      route.Match.Path = value;
+                      break;
+                    }
+                  default:
+                    break;
+                }
+              }
+            }
+          }
+
+          tokenIndex++;
+
+          if (index >= key.Length) {
+            state = State.Completed;
+          } else {
+            state = State.Processing;
+          }
+
+          continue;
+        }
+
+        if (state == State.Processing) {
+          if (index >= key.Length || key[index] == '.') {
+            state = State.Tokenizied;
+            continue;
+          }
+
+          index++;
+          continue;
+        }
+      }
+    }
+  }
+
+}

--- a/src/Xiangyao/Utils/DefaultDictionary.cs
+++ b/src/Xiangyao/Utils/DefaultDictionary.cs
@@ -25,4 +25,8 @@ public class DefaultDictionary<TKey, TValue>(int capacity = 0)
   }
 
   public IReadOnlyDictionary<TKey, TValue> ToDictionary() => dictionary;
+
+  public int Count => this.dictionary.Count;
+
+  public long LongCount => this.dictionary.LongCount();
 }

--- a/tests/Xiangyao.Benchmarks/.gitignore
+++ b/tests/Xiangyao.Benchmarks/.gitignore
@@ -1,0 +1,1 @@
+BenchmarkDotNet.Artifacts

--- a/tests/Xiangyao.Benchmarks/Cases/LabelParser.cs
+++ b/tests/Xiangyao.Benchmarks/Cases/LabelParser.cs
@@ -1,0 +1,31 @@
+namespace Xiangyao.Benchmarks;
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+
+public class LabelParserBenchmarks {
+  private ILabelParser switchCaseLabelParser = new SwitchCaseLabelParser();
+  private ILabelParser stateMachineLabelParser = new StateMachineLabelParser();
+
+  private readonly List<KeyValuePair<string, string>> labels = [
+    new ("xiangyao.enable", "true"),
+    new ("xiangyao.cluster.port", "80"),
+    new ("xiangyao.cluster.schema", "http"),
+    new ("xiangyao.routes.nginx_http.match.host", "localhost:5000"),
+    new ("xiangyao.routes.nginx_http.match.path", "{**catch-all}"),
+  ];
+
+  private void Benchmark(ILabelParser labelParser) {
+    var dict = new DefaultDictionary<string, RouteConfig>(capacity: labels.Count);
+
+    foreach (var label in labels) {
+      labelParser.Parse(label, dict);
+    }
+  }
+
+  [Benchmark]
+  public void SwitchCase() => Benchmark(switchCaseLabelParser);
+
+  [Benchmark]
+  public void StateMachine() => Benchmark(stateMachineLabelParser);
+}

--- a/tests/Xiangyao.Benchmarks/Program.cs
+++ b/tests/Xiangyao.Benchmarks/Program.cs
@@ -1,0 +1,10 @@
+namespace Xingyao.Benchmarks;
+
+using BenchmarkDotNet.Running;
+
+public static class Program {
+  public static void Main(string[] args) {
+    var summary = BenchmarkRunner.Run(typeof(Program).Assembly);
+  }
+}
+

--- a/tests/Xiangyao.Benchmarks/Xiangyao.Benchmarks.csproj
+++ b/tests/Xiangyao.Benchmarks/Xiangyao.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Xiangyao\Xiangyao.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Xiangyao.UnitTests/Docker/LabelParserTests.cs
+++ b/tests/Xiangyao.UnitTests/Docker/LabelParserTests.cs
@@ -1,0 +1,71 @@
+using Docker.DotNet.Models;
+
+namespace Xiangyao.UnitTests.Docker;
+
+public class LabelParserTests {
+  private readonly List<KeyValuePair<string, string>> labels = [
+    new ("xiangyao.enable", "true"),
+    new ("xiangyao.cluster.port", "80"),
+    new ("xiangyao.cluster.schema", "http"),
+    new ("xiangyao.routes.nginx_http.match.host", "localhost:5000"),
+    new ("xiangyao.routes.nginx_http.match.path", "{**catch-all}"),
+  ];
+
+  private readonly ContainerListResponse emptyContainerListResponse = new() {
+  };
+
+  private readonly ContainerListResponse containerListResponse = new() {
+    NetworkSettings = new SummaryNetworkSettings {
+      Networks = new Dictionary<string, EndpointSettings> {
+        {
+          "bridge",
+          new EndpointSettings {
+            Aliases = new List<string> {
+              "nginx"
+            }
+          }
+        }
+      }
+    }
+  };
+
+  [Theory]
+  [InlineData(typeof(StateMachineLabelParser))]
+  [InlineData(typeof(SwitchCaseLabelParser))]
+  public void Test_Parse_1_Label(Type parserType) {
+    var parser = Activator.CreateInstance(parserType) as ILabelParser;
+
+    var dict = new DefaultDictionary<string, RouteConfig>(capacity: labels.Count);
+
+    foreach (var label in labels) {
+      parser!.Parse(label, dict);
+    }
+
+    dict.Count.Should().Be(1);
+    var value = dict["nginx_http"];
+
+    value.Should().NotBeNull();
+    value!.Match.Hosts.Should().Contain("localhost:5000");
+    value!.Match.Path.Should().Be("{**catch-all}");
+  }
+
+  [Fact]
+  public void Test_Parse_Default() {
+    ILabelParser parser = new NoopLabelParser();
+
+    parser.ParseEnabled(labels).Should().BeTrue();
+
+    parser.ParsePort(labels).Should().Be(80);
+    parser.ParseSchema(labels).Should().Be("http");
+
+    parser.ParseHost(emptyContainerListResponse).Should().BeNullOrEmpty();
+
+    parser.ParseHost(containerListResponse).Should().Be("nginx");
+  }
+
+  internal class NoopLabelParser : ILabelParser {
+    public bool Parse(KeyValuePair<string, string> label, DefaultDictionary<string, RouteConfig> parsedLabels) {
+      return false;
+    }
+  }
+}

--- a/tests/Xiangyao.UnitTests/Xiangyao.UnitTests.csproj
+++ b/tests/Xiangyao.UnitTests/Xiangyao.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Xiangyao\Xiangyao.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The state machine code looks more elegant (really?)
but the performance is a bit bad

```
// * Summary *

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3)
12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2


| Method       | Mean     | Error   | StdDev  |
|------------- |---------:|--------:|--------:|
| SwitchCase   | 309.4 ns | 5.93 ns | 5.83 ns |
| StateMachine | 408.5 ns | 8.13 ns | 6.79 ns |

// * Hints *
Outliers
  LabelParserBenchmarks.SwitchCase: Default   -> 1 outlier  was  detected (299.49 ns)
  LabelParserBenchmarks.StateMachine: Default -> 2 outliers were removed (433.41 ns, 449.35 ns)

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ns   : 1 Nanosecond (0.000000001 sec)

// ***** BenchmarkRunner: End *****
Run time: 00:00:41 (41.45 sec), executed benchmarks: 2

Global total time: 00:00:46 (46.74 sec), executed benchmarks: 2
// * Artifacts cleanup *
Artifacts cleanup is finished
```

Keep using the switch case one, need to add option to change